### PR TITLE
Use an ArenaAllocator in parseRegistry

### DIFF
--- a/src/glregistry.zig
+++ b/src/glregistry.zig
@@ -558,7 +558,7 @@ pub fn parseRegistry(
                         .enums => try extractEnumGroup(&registry, tag),
                         .feature => {
                             var tree = try xml.parseXml(tree_allocator, reader, tag.*);
-                            defer _ = tree_arena.reset(.free_all);
+                            defer _ = tree_arena.reset(.retain_capacity);
                             defer _ = element_stack.pop();
 
                             try extractFeature(&registry, &tree);
@@ -573,7 +573,7 @@ pub fn parseRegistry(
                     .commands => switch (elemtag) {
                         .command => {
                             var tree = try xml.parseXml(tree_allocator, reader, tag.*);
-                            defer _ = tree_arena.reset(.free_all);
+                            defer _ = tree_arena.reset(.retain_capacity);
                             defer _ = element_stack.pop();
 
                             try extractCommand(&registry, &tree);
@@ -586,7 +586,7 @@ pub fn parseRegistry(
                                 continue;
                             }
                             var tree = try xml.parseXml(tree_allocator, reader, tag.*);
-                            defer _ = tree_arena.reset(.free_all);
+                            defer _ = tree_arena.reset(.retain_capacity);
                             defer _ = element_stack.pop();
 
                             try extractExtension(&registry, &tree);


### PR DESCRIPTION
```
Benchmark 1: ./zig-out/bin/zglgen --api gl:4.6
  Time (mean ± σ):      1.355 s ±  0.010 s    [User: 0.867 s, System: 0.453 s]
  Range (min … max):    1.343 s …  1.380 s    10 runs
 
Benchmark 2: ../zig-out/bin/zglgen --api gl:4.6
  Time (mean ± σ):      3.948 s ±  0.028 s    [User: 2.352 s, System: 1.520 s]
  Range (min … max):    3.913 s …  4.016 s    10 runs
 
Summary
  ./zig-out/bin/zglgen --api gl:4.6 ran
    2.91 ± 0.03 times faster than ../zig-out/bin/zglgen --api gl:4.6
```

I should experiment more with how the arena gets cleared.