### PR TITLE
Update to Zig 0.13.0

### DIFF
--- a/src/zig_generator.zig
+++ b/src/zig_generator.zig
@@ -250,7 +250,7 @@ pub fn writeFunctionParameterName(param: Registry.Command.Param, index: ?usize, 
 
     // reserved keywords that OpenGL
     // uses as parameter names
-    const keywords = std.ComptimeStringMap(void, .{
+    const keywords = std.StaticStringMap(void).initComptime(.{
         &.{"type"},
         &.{"u1"},
         &.{"u2"},


### PR DESCRIPTION
std.ComptimeStringMap has been renamed to std.StaticStringMap
